### PR TITLE
Fixed jQuery caching related memory leak

### DIFF
--- a/jquery.jgrowl.js
+++ b/jquery.jgrowl.js
@@ -228,8 +228,8 @@
 		        .append($('<div/>').addClass('jGrowl-header').html(o.header))
 		        .append($('<div/>').addClass('jGrowl-message').html(message))
 		        .data("jGrowl", o).addClass(o.theme).children('div.jGrowl-close').bind("click.jGrowl", function() {
-		        	$(this).parent().trigger('jGrowl.beforeClose');
-		        })		      
+		        	$(this).parent().trigger('jGrowl.beforeClose');		        
+		        })
 		        .parent();
 
 


### PR DESCRIPTION
jQuery caches (unique) strings, so it's better to construct the element using API rather than giving jQuery new (potentially different because on the message) string to cache.
