### PR TITLE
add src and style fields to package.json for increased compatibility. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url" : "http://stanlemon.net"
   },
   "src": "jquery.jgrowl.js",
-  "style": "jquery.jgrowl.min.css",
+  "style": "jquery.jgrowl.css",
   "repository" : {
     "type" : "git",
     "url" : "http://github.com/stanlemon/jGrowl.git"


### PR DESCRIPTION
This helps scripts (such as browserify) find the js and css files. 
