### PR TITLE
Added an undefined check in the condition that checks if the notificatio...

### DIFF
--- a/jquery.jgrowl.js
+++ b/jquery.jgrowl.js
@@ -278,7 +278,7 @@
 						if ($.support.opacity === false)
 							this.style.removeAttribute('filter');
 
-						if ( $(this).data("jGrowl") !== null ) // Happens when a notification is closing before it's open.
+						if ( $(this).data("jGrowl") !== null && typeof $(this).data("jGrowl") !== 'undefined') // Happens when a notification is closing before it's open.
 							$(this).data("jGrowl").created = new Date();
 
 						$(this).trigger('jGrowl.afterOpen');


### PR DESCRIPTION
...n is closing before it's open.  Without this check we were getting a javascript undefined error on the next line when '.created' was trying to be run on an undefined object.
