### PR TITLE
Fix error looping in IE 11

### DIFF
--- a/jquery.jgrowl.js
+++ b/jquery.jgrowl.js
@@ -371,19 +371,27 @@
 				// some error in chage ^^
 				var instance = $(e).data('jGrowl.instance');
 				if (undefined !== instance) {
-					instance.update();
+					try {
+						instance.update();
+					} catch (e)
+						clearInterval(self.interval);
+                      				throw e;
+                    			}
 				}
 			}, parseInt(this.defaults.check, 10));
 		},
 
 		/** Shutdown jGrowl, removing it and clearing the interval **/
 		shutdown: function() {
+		    try {
 			$(this.element).removeClass('jGrowl')
-				.find('.jGrowl-notification').trigger('jGrowl.close')
-				.parent().empty()
-			;
-
+			    .find('.jGrowl-notification').trigger('jGrowl.close')
+			    .parent().empty();
+		    } catch (e) {
+			throw e;
+		    } finally {
 			clearInterval(this.interval);
+		    }
 		},
 
 		close: function() {

--- a/jquery.jgrowl.js
+++ b/jquery.jgrowl.js
@@ -373,10 +373,10 @@
 				if (undefined !== instance) {
 					try {
 						instance.update();
-					} catch (e)
-						clearInterval(self.interval);
-                      				throw e;
-                    			}
+					} catch (e) {
+						instance.shutdown();
+						throw e;
+					}
 				}
 			}, parseInt(this.defaults.check, 10));
 		},


### PR DESCRIPTION
If JQuery lost current context  unrecoverable error occurs:

```
Invalid argument.
    at select(/lib/jquery-1.11.0.js:2510)
    at Sizzle(/lib/jquery-1.11.0.js:880)
    at find(/lib/jquery-1.11.0.js:2683)
    at update(/lib/jquery.jgrowl.js:339)
    at Anonymous function(/lib/jquery.jgrowl.js:368)
```
I think that it is necessary to wrap the complex places that can lead to infinite loops in try...catch.